### PR TITLE
show image only when loaded

### DIFF
--- a/public/stylesheets/gallery.css
+++ b/public/stylesheets/gallery.css
@@ -22,6 +22,7 @@
 
 .playlist__image {
     width: 100%;
+    visibility: hidden;
 }
 
 .playlist__name {

--- a/views/gallery/playlist.ejs
+++ b/views/gallery/playlist.ejs
@@ -1,4 +1,4 @@
 <a class="playlist" href="/summary?playlistId=<%= playlist.id %>">
-    <img alt="<%= playlist.name %>" class="playlist__image" src="<%= playlist.thumbnailUrl%>/width/200/height/113">
+    <img alt="<%= playlist.name %>" class="playlist__image" onload="this.style.visibility = 'visible'" src="<%= playlist.thumbnailUrl%>/width/200/height/113">
     <span class="playlist__name"><%= playlist.name %></span>
 </a>


### PR DESCRIPTION
handle the thumbnail creation phase (hide image instead of showing broken image)

![image](https://user-images.githubusercontent.com/4751797/72688477-4a487700-3b10-11ea-8b14-9b73e1038394.png)

